### PR TITLE
Remove keyboard observer when object was deallocated

### DIFF
--- a/Sources/LNPopupUI/Private/LNPopupUICustomPopupBarController.swift
+++ b/Sources/LNPopupUI/Private/LNPopupUICustomPopupBarController.swift
@@ -106,4 +106,9 @@ internal class LNPopupUICustomPopupBarController : LNPopupCustomBarViewControlle
 	required init?(coder: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}
+
+  deinit {
+    NotificationCenter.default.removeObserver(keyboardObserver1!)
+    NotificationCenter.default.removeObserver(keyboardObserver2!)
+  }
 }


### PR DESCRIPTION
Hi, I have got an [issue](https://github.com/blackcandy-org/black_candy_ios/issues/10) when I am using LNPopupUI. And I found out that's because `LNPopupUICustomPopupBarController` add keyboard observers on init. But when `LNPopupUICustomPopupBarController` was deallocated, those observers didn't remove. So I will get fatal error when I click some input when LNPopupUI didn't appear on view. To resolve this, I add some code to remove those observers when object was deallocated.